### PR TITLE
Bump dependencies

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -15,14 +15,14 @@
         "elm/project-metadata-utils": "1.0.1 <= v < 2.0.0",
         "elm/regex": "1.0.0 <= v < 2.0.0",
         "elm-community/dict-extra": "2.4.0 <= v < 3.0.0",
-        "erlandsona/assoc-set": "1.1.0 <= v < 2.0.0",
-        "jfmengels/elm-review": "2.3.8 <= v < 3.0.0",
-        "miniBill/elm-codec": "2.0.0 <= v < 3.0.0",
+        "erlandsona/assoc-set": "1.1.3 <= v < 2.0.0",
+        "jfmengels/elm-review": "2.9.1 <= v < 3.0.0",
+        "miniBill/elm-codec": "2.2.0 <= v < 3.0.0",
         "pzp1997/assoc-list": "1.0.0 <= v < 2.0.0",
         "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0",
-        "stil4m/elm-syntax": "7.2.1 <= v < 8.0.0",
-        "the-sett/elm-pretty-printer": "2.2.3 <= v < 3.0.0",
-        "the-sett/elm-syntax-dsl": "5.2.0 <= v < 6.0.0"
+        "stil4m/elm-syntax": "7.3.7 <= v < 8.0.0",
+        "the-sett/elm-pretty-printer": "3.1.0 <= v < 4.0.0",
+        "the-sett/elm-syntax-dsl": "6.0.3 <= v < 7.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.2.2 <= v < 2.0.0"


### PR DESCRIPTION
This fixes an issue where the library could not be installed alongside `mdgriffith/elm-codegen` due to incompatible mutual dependencies.